### PR TITLE
Update requirements.txt - add missing typing-extensions

### DIFF
--- a/usr/lib/python3/dist-packages/linuxmusterApi/requirements.txt
+++ b/usr/lib/python3/dist-packages/linuxmusterApi/requirements.txt
@@ -3,6 +3,6 @@ fastapi
 pyOpenSSL
 python-ldap
 pyyaml
+typing-extensions
 uvicorn
 websockets>=11.0.3
-


### PR DESCRIPTION
Add missing typing-extensions python module which is used here:

https://github.com/linuxmuster/linuxmuster-api/blob/lmn73/usr/lib/python3/dist-packages/linuxmusterApi/security/basic_auth.py#L7