### PR TITLE
Add subnets API endpoints

### DIFF
--- a/usr/lib/python3/dist-packages/linuxmusterApi/main.py
+++ b/usr/lib/python3/dist-packages/linuxmusterApi/main.py
@@ -78,6 +78,7 @@ from routers_v1 import (
     schools,
     server,
     sessions,
+    subnets,
     teachers,
     users,
     vdi,
@@ -124,6 +125,7 @@ app.include_router(samba.router, prefix="/v1")
 app.include_router(schoolclasses.router, prefix="/v1")
 app.include_router(server.router, prefix="/v1")
 app.include_router(sessions.router, prefix="/v1")
+app.include_router(subnets.router, prefix="/v1")
 app.include_router(schools.router, prefix="/v1")
 app.include_router(teachers.router, prefix="/v1")
 app.include_router(users.router, prefix="/v1")

--- a/usr/lib/python3/dist-packages/linuxmusterApi/routers_v1/body_schemas.py
+++ b/usr/lib/python3/dist-packages/linuxmusterApi/routers_v1/body_schemas.py
@@ -195,6 +195,31 @@ class Device(BaseModel):
     unicodePwd: str | None = None
     unicodePwd_hash: str | None = None
 
+class Subnet(BaseModel):
+    """
+    One line of /etc/linuxmuster/subnets.csv.
+
+    All fields are optional so that comment and empty lines (whose *network*
+    field then starts with '#') can be round-tripped without loss.
+    """
+
+
+    network: str | None = None
+    routerIp: str | None = None
+    beginRange: str | None = None
+    endRange: str | None = None
+    nameServer: str | None = None
+    nextServer: str | None = None
+    setupFlag: str | None = None
+
+class SubnetList(BaseModel):
+    """
+    Content of /etc/linuxmuster/subnets.csv, one Subnet per line.
+    """
+
+
+    data: list[Subnet] | None = None
+
 # --- LINBO Models ---
 
 class LinboBatchMacs(BaseModel):

--- a/usr/lib/python3/dist-packages/linuxmusterApi/routers_v1/subnets.py
+++ b/usr/lib/python3/dist-packages/linuxmusterApi/routers_v1/subnets.py
@@ -1,0 +1,113 @@
+import os
+from fastapi import APIRouter, Depends, HTTPException
+
+from security import RoleChecker, AuthenticatedUser
+from linuxmusterTools.lmnfile import LMNFile
+from linuxmusterTools.subnets import Subnets, import_subnets, SUBNETS_PATH
+from .body_schemas import MgmtList
+
+router = APIRouter(
+    prefix="/subnets",
+    tags=["Subnets"],
+    responses={404: {"description": "Not found"}},
+)
+
+@router.get("/list", name="List all subnets")
+def get_all_subnets(who: AuthenticatedUser = Depends(RoleChecker("G"))):
+    """
+    ## List the content of /etc/linuxmuster/subnets.csv.
+
+    Every line of the CSV file is returned as a dict, including comment lines
+    (their *network* field then starts with a '#'), so that the list can be
+    edited and posted back without losing comments.
+
+    Subnets are not bound to a school: there is a single, server wide file.
+
+    ### Access
+    - global-administrators
+
+    \f
+    :param who: User requesting the data, read from API Token
+    :type who: AuthenticatedUser
+    :return: List of all subnets (list of dict, one dict per line in CSV)
+    :rtype: list
+    """
+
+
+    if not os.path.isfile(SUBNETS_PATH):
+        return []
+
+    with LMNFile(SUBNETS_PATH, 'r') as f:
+        return f.read()
+
+@router.post("/list", name="Write content of subnets.csv")
+def post_subnets_list_content(content: MgmtList, who: AuthenticatedUser = Depends(RoleChecker("G"))):
+    """
+    ## Write the content of /etc/linuxmuster/subnets.csv.
+
+    This will overwrite the content of the CSV file, but LMNFile automatically
+    makes a backup of the old CSV file. The changes only take effect on the
+    running system after linuxmuster-import-subnets has been run (see the
+    import-subnets endpoint).
+
+    ### Access
+    - global-administrators
+
+    \f
+    :param who: User requesting the data, read from API Token
+    :type who: AuthenticatedUser
+    :param content: Content of the CSV, see MgmtList attributes
+    :type content: MgmtList
+    :return: Content of the csv file (list of dict, one dict per line in CSV)
+    :rtype: list
+    """
+
+
+    try:
+        with LMNFile(SUBNETS_PATH, 'w') as subnets_file:
+            return subnets_file.write(content.data)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Error writing {SUBNETS_PATH}: {str(e)}")
+
+@router.get("/check", name="Validate subnets.csv")
+def check_subnets(who: AuthenticatedUser = Depends(RoleChecker("G"))):
+    """
+    ## Validate the content of /etc/linuxmuster/subnets.csv.
+
+    Checks that networks are valid CIDR, that router/range/server addresses are
+    valid IPs belonging to their network and that the setup flag is valid.
+
+    ### Access
+    - global-administrators
+
+    \f
+    :param who: User requesting the data, read from API Token
+    :type who: AuthenticatedUser
+    :return: {"valid": bool, "report": list of error messages}
+    :rtype: dict
+    """
+
+
+    report = Subnets().check_conf()
+    return {"valid": report is False, "report": report or []}
+
+@router.get("/list/import-subnets", name="Run linuxmuster-import-subnets")
+def do_import_subnets(who: AuthenticatedUser = Depends(RoleChecker("G"))):
+    """
+    ## Run linuxmuster-import-subnets.
+
+    This regenerates the DHCP, ntp and netplan configuration from
+    /etc/linuxmuster/subnets.csv and restarts the affected services.
+
+    ### Access
+    - global-administrators
+
+    \f
+    :param who: User requesting the data, read from API Token
+    :type who: AuthenticatedUser
+    :return: Return code and output of linuxmuster-import-subnets
+    :rtype: dict
+    """
+
+
+    return import_subnets()

--- a/usr/lib/python3/dist-packages/linuxmusterApi/routers_v1/subnets.py
+++ b/usr/lib/python3/dist-packages/linuxmusterApi/routers_v1/subnets.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from security import RoleChecker, AuthenticatedUser
 from linuxmusterTools.lmnfile import LMNFile
 from linuxmusterTools.subnets import Subnets, import_subnets, SUBNETS_PATH
-from .body_schemas import MgmtList
+from .body_schemas import SubnetList
 
 router = APIRouter(
     prefix="/subnets",
@@ -12,8 +12,8 @@ router = APIRouter(
     responses={404: {"description": "Not found"}},
 )
 
-@router.get("/list", name="List all subnets")
-def get_all_subnets(who: AuthenticatedUser = Depends(RoleChecker("G"))):
+@router.get("/", name="List all subnets")
+def get_subnets(who: AuthenticatedUser = Depends(RoleChecker("G"))):
     """
     ## List the content of /etc/linuxmuster/subnets.csv.
 
@@ -40,8 +40,8 @@ def get_all_subnets(who: AuthenticatedUser = Depends(RoleChecker("G"))):
     with LMNFile(SUBNETS_PATH, 'r') as f:
         return f.read()
 
-@router.post("/list", name="Write content of subnets.csv")
-def post_subnets_list_content(content: MgmtList, who: AuthenticatedUser = Depends(RoleChecker("G"))):
+@router.post("/", name="Write content of subnets.csv")
+def post_subnets(content: SubnetList, who: AuthenticatedUser = Depends(RoleChecker("G"))):
     """
     ## Write the content of /etc/linuxmuster/subnets.csv.
 
@@ -56,16 +56,18 @@ def post_subnets_list_content(content: MgmtList, who: AuthenticatedUser = Depend
     \f
     :param who: User requesting the data, read from API Token
     :type who: AuthenticatedUser
-    :param content: Content of the CSV, see MgmtList attributes
-    :type content: MgmtList
+    :param content: Content of the CSV, see SubnetList attributes
+    :type content: SubnetList
     :return: Content of the csv file (list of dict, one dict per line in CSV)
     :rtype: list
     """
 
 
+    rows = [subnet.model_dump() for subnet in (content.data or [])]
+
     try:
         with LMNFile(SUBNETS_PATH, 'w') as subnets_file:
-            return subnets_file.write(content.data)
+            return subnets_file.write(rows)
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"Error writing {SUBNETS_PATH}: {str(e)}")
 
@@ -91,7 +93,7 @@ def check_subnets(who: AuthenticatedUser = Depends(RoleChecker("G"))):
     report = Subnets().check_conf()
     return {"valid": report is False, "report": report or []}
 
-@router.get("/list/import-subnets", name="Run linuxmuster-import-subnets")
+@router.get("/import-subnets", name="Run linuxmuster-import-subnets")
 def do_import_subnets(who: AuthenticatedUser = Depends(RoleChecker("G"))):
     """
     ## Run linuxmuster-import-subnets.


### PR DESCRIPTION
Add a router to manage `/etc/linuxmuster/subnets.csv`, analogous to the devices endpoints:

| Endpoint | Purpose |
|---|---|
| `GET /v1/subnets/list` | read the CSV (comment lines preserved, round-trip safe) |
| `POST /v1/subnets/list` | overwrite the CSV (LMNFile makes an automatic backup) |
| `GET /v1/subnets/check` | validate the CSV content → `{valid, report}` |
| `GET /v1/subnets/list/import-subnets` | run `linuxmuster-import-subnets` |

Subnets are server-wide (not per-school) and network configuration is global, so all routes are restricted to **global-administrators** (`RoleChecker("G")`).

The underlying logic lives in `linuxmusterTools.subnets` (linuxmuster/linuxmuster-tools#9), which must be released first.

Tested end-to-end against a real server: list (comments preserved), check (`{valid: true}`), a modifying write + restore, and `import-subnets` (returncode 0).