### PR TITLE
Add a pytest config and a make target to run the suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,15 @@
+API_DIR = usr/lib/python3/dist-packages/linuxmusterApi
+
+# The API ships its own interpreter; the system python3 has neither fastapi nor
+# linuxmusterTools. Override on a machine where it lives somewhere else.
+PYTHON ?= /opt/linuxmuster/bin/python3
+
 all: build
 
 deb:
 	dpkg-buildpackage -rfakeroot -tc -sa -us -uc -I".gitignore" -I".git" -I".github" -I".idea" -I"docs"
 
+test:
+	cd $(API_DIR) && $(PYTHON) -m pytest $(PYTEST_ARGS)
+
+.PHONY: all deb test

--- a/usr/lib/python3/dist-packages/linuxmusterApi/pytest.ini
+++ b/usr/lib/python3/dist-packages/linuxmusterApi/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths = pytests
+
+# rootdir is this directory on purpose: main.py mounts StaticFiles(directory="static"),
+# which resolves against the working directory, so importing the app from anywhere else
+# fails before a single test runs.


### PR DESCRIPTION
The 206 tests under `linuxmusterApi/pytests` have no configured entry point — no `pytest.ini`, no make target, no mention in the README, and `release.yml` only builds the package. Running them currently means knowing two things that are written down nowhere:

- pytest has to start **inside `linuxmusterApi/`**, because `main.py` mounts `StaticFiles(directory="static")`, which resolves against the working directory. From anywhere else the app import raises `RuntimeError: Directory 'static' does not exist` before a single test runs.
- it has to run under **the interpreter the API ships** (`/opt/linuxmuster/bin/python3`, per `ExecStart` in the unit file). The system `python3` has neither `fastapi` nor `linuxmusterTools`.

## What this adds

`usr/lib/python3/dist-packages/linuxmusterApi/pytest.ini` — deliberately in that directory rather than at the repository root, so `rootdir` lands where the app can be imported. It sets `testpaths = pytests` and carries a comment explaining why it lives there, since the location looks arbitrary otherwise.

`make test` in the Makefile:

```make
API_DIR = usr/lib/python3/dist-packages/linuxmusterApi
PYTHON ?= /opt/linuxmuster/bin/python3

test:
	cd $(API_DIR) && $(PYTHON) -m pytest $(PYTEST_ARGS)
```

`PYTHON` is overridable for a machine where the interpreter lives elsewhere, and `PYTEST_ARGS` allows a narrower run (`make test PYTEST_ARGS="pytests/test_linbo_drivers.py -q"`).

Nothing about how the tests are written changes, and no test file is touched.

## Verified

On an installed 7.4 server: `make test PYTEST_ARGS="--collect-only -q"` collects **435 tests**, and `make test PYTEST_ARGS="pytests/test_linbo_drivers.py pytests/test_checks.py -q"` gives **16 passed**.

The rest of the suite is integration-style and needs `pytests/credentials.py` filled with real LDAP users and fixture names, so a bare `make test` on a machine without that configuration reports failures. That is the existing state of the suite, not something this change introduces — the target just makes it runnable in one command.

## Possible follow-up, not done here

Three files (`test_linbo_drivers.py`, `test_checks.py`, `test_rate_limiter.py`) need no live data, the other sixteen do. A marker on that split would let `make test` default to the subset that runs anywhere and keep the full run behind `make test PYTEST_ARGS="-m integration"`. That touches every test file, so I have left it out — happy to prepare it separately if you would find it useful.
