### PR TITLE
Expose the LINBO host state and boot log endpoints

### DIFF
--- a/usr/lib/python3/dist-packages/linuxmusterApi/pytests/test_linbo_hosts.py
+++ b/usr/lib/python3/dist-packages/linuxmusterApi/pytests/test_linbo_hosts.py
@@ -1,0 +1,213 @@
+from unittest.mock import Mock
+
+import pytest
+from fastapi import HTTPException
+
+from routers_v1 import linbo
+from routers_v1.body_schemas import LinboHostScanRequest, LinboWolRequest
+from security import RoleChecker
+
+
+@pytest.fixture
+def linbo_backends(monkeypatch):
+    devices = Mock()
+    boot_logs = Mock()
+    scan = Mock(return_value=[])
+    wol = Mock(return_value={})
+    image_status = Mock(return_value={})
+
+    monkeypatch.setattr(linbo, "Devices", lambda school: devices)
+    monkeypatch.setattr(linbo, "LinboBootLogs", lambda: boot_logs)
+    monkeypatch.setattr(linbo, "scan_hosts_sync", scan)
+    monkeypatch.setattr(linbo, "send_wol_bulk", wol)
+    monkeypatch.setattr(linbo, "get_host_image_status", image_status)
+    monkeypatch.setattr(linbo, "check_valid_school_or_404", lambda school: school)
+    return devices, boot_logs, scan, wol, image_status
+
+
+def test_new_routes_are_registered():
+    expected = {
+        ("POST", "/linbo/hosts/scan"),
+        ("POST", "/linbo/wol"),
+        ("GET", "/linbo/hosts/image-status"),
+        ("GET", "/linbo/boot-logs"),
+        ("GET", "/linbo/boot-logs/{filename}"),
+        ("DELETE", "/linbo/boot-logs/{filename}"),
+    }
+    actual = {
+        (method, route.path)
+        for route in linbo.router.routes
+        for method in route.methods
+    }
+    assert expected <= actual
+
+
+def test_every_linbo_route_is_global_admin_only():
+    for route in linbo.router.routes:
+        checkers = [
+            dependency.call
+            for dependency in route.dependant.dependencies
+            if isinstance(dependency.call, RoleChecker)
+        ]
+        assert len(checkers) == 1, f"{route.path} has {len(checkers)} role checkers"
+        assert checkers[0].roles == ["globaladministrator"], route.path
+
+
+def test_scan_without_macs_probes_every_client(linbo_backends):
+    devices, _, scan, _, _ = linbo_backends
+    clients = [{"mac": "00:11:22:33:44:55", "ip": "10.0.0.100", "hostname": "pc100"}]
+    devices.get_clients.return_value = clients
+    scan.return_value = [{"mac": clients[0]["mac"], "online": True}]
+
+    result = linbo.scan_hosts(LinboHostScanRequest(), "default-school", None)
+
+    scan.assert_called_once_with(clients)
+    devices.get_hosts_by_macs.assert_not_called()
+    assert result["hosts"] == scan.return_value
+    assert "scannedAt" in result
+
+
+def test_scan_with_macs_probes_only_those_hosts(linbo_backends):
+    devices, _, scan, _, _ = linbo_backends
+    macs = ["00:11:22:33:44:55"]
+    hosts = [{"mac": macs[0], "ip": "10.0.0.100", "hostname": "pc100"}]
+    devices.get_hosts_by_macs.return_value = hosts
+
+    linbo.scan_hosts(LinboHostScanRequest(macs=macs), "default-school", None)
+
+    devices.get_hosts_by_macs.assert_called_once_with(macs)
+    devices.get_clients.assert_not_called()
+    scan.assert_called_once_with(hosts)
+
+
+def test_scan_rejects_more_than_500_macs(linbo_backends):
+    _, _, scan, _, _ = linbo_backends
+    body = LinboHostScanRequest(macs=[f"00:00:00:00:00:{i:02x}" for i in range(501)])
+
+    with pytest.raises(HTTPException) as error:
+        linbo.scan_hosts(body, "default-school", None)
+
+    assert error.value.status_code == 400
+    scan.assert_not_called()
+
+
+def test_scan_without_any_host_is_404(linbo_backends):
+    devices, _, scan, _, _ = linbo_backends
+    devices.get_clients.return_value = []
+
+    with pytest.raises(HTTPException) as error:
+        linbo.scan_hosts(LinboHostScanRequest(), "default-school", None)
+
+    assert error.value.status_code == 404
+    scan.assert_not_called()
+
+
+def test_wol_delegates_with_packet_parameters(linbo_backends):
+    _, _, _, wol, _ = linbo_backends
+    macs = ["00:11:22:33:44:55"]
+    wol.return_value = {"total": 1, "successful": 1, "failed": 0, "results": []}
+
+    body = LinboWolRequest(macs=macs, broadcast="10.0.0.255", port=7, count=5)
+    result = linbo.wake_hosts(body, None)
+
+    wol.assert_called_once_with(macs, broadcast="10.0.0.255", port=7, count=5)
+    assert result == wol.return_value
+
+
+def test_wol_without_macs_is_rejected(linbo_backends):
+    _, _, _, wol, _ = linbo_backends
+
+    with pytest.raises(HTTPException) as error:
+        linbo.wake_hosts(LinboWolRequest(macs=[]), None)
+
+    assert error.value.status_code == 400
+    wol.assert_not_called()
+
+
+def test_wol_rejects_more_than_500_macs(linbo_backends):
+    _, _, _, wol, _ = linbo_backends
+    body = LinboWolRequest(macs=[f"00:00:00:00:00:{i:02x}" for i in range(501)])
+
+    with pytest.raises(HTTPException) as error:
+        linbo.wake_hosts(body, None)
+
+    assert error.value.status_code == 400
+    wol.assert_not_called()
+
+
+def test_image_status_reports_total(linbo_backends):
+    _, _, _, _, image_status = linbo_backends
+    image_status.return_value = {"pc100": {"lastSync": "2026-03-24T11:42:00.000Z"}}
+
+    result = linbo.hosts_image_status(None)
+
+    assert result == {"hosts": image_status.return_value, "total": 1}
+
+
+def test_boot_logs_are_listed_with_total(linbo_backends):
+    _, boot_logs, _, _, _ = linbo_backends
+    boot_logs.list_logs.return_value = [{"filename": "pc100.log", "size": 12}]
+
+    result = linbo.list_boot_logs(None)
+
+    assert result == {"logs": boot_logs.list_logs.return_value, "total": 1}
+
+
+def test_boot_log_is_returned_as_plain_text(linbo_backends):
+    _, boot_logs, _, _, _ = linbo_backends
+    boot_logs.read_log.return_value = "sync finished"
+
+    response = linbo.read_boot_log("pc100.log", None)
+
+    boot_logs.read_log.assert_called_once_with("pc100.log")
+    assert response.body == b"sync finished"
+
+
+def test_missing_boot_log_is_404(linbo_backends):
+    _, boot_logs, _, _, _ = linbo_backends
+    boot_logs.read_log.return_value = None
+
+    with pytest.raises(HTTPException) as error:
+        linbo.read_boot_log("nope.log", None)
+
+    assert error.value.status_code == 404
+
+
+def test_unsafe_boot_log_name_is_400(linbo_backends):
+    _, boot_logs, _, _, _ = linbo_backends
+    boot_logs.read_log.side_effect = ValueError("Unsafe filename: ../../etc/shadow")
+
+    with pytest.raises(HTTPException) as error:
+        linbo.read_boot_log("../../etc/shadow", None)
+
+    assert error.value.status_code == 400
+
+
+def test_boot_log_deletion_reports_the_filename(linbo_backends):
+    _, boot_logs, _, _, _ = linbo_backends
+    boot_logs.delete_log.return_value = True
+
+    assert linbo.delete_boot_log("pc100.log", None) == {
+        "filename": "pc100.log",
+        "status": "deleted",
+    }
+
+
+def test_deleting_a_missing_boot_log_is_404(linbo_backends):
+    _, boot_logs, _, _, _ = linbo_backends
+    boot_logs.delete_log.return_value = False
+
+    with pytest.raises(HTTPException) as error:
+        linbo.delete_boot_log("nope.log", None)
+
+    assert error.value.status_code == 404
+
+
+def test_unsafe_name_on_delete_is_400(linbo_backends):
+    _, boot_logs, _, _, _ = linbo_backends
+    boot_logs.delete_log.side_effect = ValueError("Unsafe filename: ../../etc/shadow")
+
+    with pytest.raises(HTTPException) as error:
+        linbo.delete_boot_log("../../etc/shadow", None)
+
+    assert error.value.status_code == 400

--- a/usr/lib/python3/dist-packages/linuxmusterApi/routers_v1/body_schemas.py
+++ b/usr/lib/python3/dist-packages/linuxmusterApi/routers_v1/body_schemas.py
@@ -258,6 +258,25 @@ class LinboBatchMacs(BaseModel):
 
     macs: list[str]
 
+class LinboHostScanRequest(BaseModel):
+    """
+    MAC addresses to probe for online status. Empty means every client of the school.
+    """
+
+
+    macs: list[str] = []
+
+class LinboWolRequest(BaseModel):
+    """
+    MAC addresses to wake, with the magic packet parameters.
+    """
+
+
+    macs: list[str]
+    broadcast: str | None = None
+    port: int = 9
+    count: int = 3
+
 class StartConfRawBody(BaseModel):
     """
     Raw start.conf content, keeps comments, but will not be parsed.

--- a/usr/lib/python3/dist-packages/linuxmusterApi/routers_v1/linbo.py
+++ b/usr/lib/python3/dist-packages/linuxmusterApi/routers_v1/linbo.py
@@ -15,7 +15,12 @@ from fastapi.responses import PlainTextResponse, StreamingResponse, Response
 
 from security import AuthenticatedUser, RoleChecker
 from utils.checks import check_valid_school_or_404
-from .body_schemas import LinboBatchMacs, StartConfRawBody
+from .body_schemas import (
+    LinboBatchMacs,
+    LinboHostScanRequest,
+    LinboWolRequest,
+    StartConfRawBody,
+)
 
 
 from linuxmusterTools.ldapconnector import LMNLdapReader as lr
@@ -406,6 +411,175 @@ def dhcp_export_isc(
 
     exporter = LinboDhcpExporter()
     return exporter.get_isc_dhcp(school)
+
+
+# ── Host state ─────────────────────────────────────────────────────
+
+
+@router.post("/hosts/scan", name="Probe hosts for online status")
+def scan_hosts(
+    body: LinboHostScanRequest,
+    school: str = "default-school",
+    who: AuthenticatedUser = Depends(RoleChecker("G")),
+):
+    """
+    ## Probe hosts over TCP and report which ones are online.
+
+    An empty MAC list scans every client of the school.
+
+    ### Access
+    - global-administrators
+
+    \f
+    :param body: MAC addresses to probe, empty for all clients of the school
+    :param school: School name (default: default-school)
+    """
+
+
+    check_valid_school_or_404(school)
+
+    if len(body.macs) > 500:
+        raise HTTPException(status_code=400, detail="Maximum 500 MACs per request")
+
+    devices_mgr = Devices(school=school)
+    hosts = devices_mgr.get_hosts_by_macs(body.macs) if body.macs else devices_mgr.get_clients()
+
+    if not hosts:
+        raise HTTPException(status_code=404, detail="No hosts found")
+
+    return {
+        "hosts": scan_hosts_sync(hosts),
+        "scannedAt": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+@router.post("/wol", name="Wake hosts with a magic packet")
+def wake_hosts(
+    body: LinboWolRequest,
+    who: AuthenticatedUser = Depends(RoleChecker("G")),
+):
+    """
+    ## Send Wake-on-LAN magic packets to a list of MAC addresses.
+
+    ### Access
+    - global-administrators
+
+    \f
+    :param body: MAC addresses to wake, with broadcast address, port and packet count
+    """
+
+
+    if not body.macs:
+        raise HTTPException(status_code=400, detail="At least one MAC address is required")
+
+    if len(body.macs) > 500:
+        raise HTTPException(status_code=400, detail="Maximum 500 MACs per request")
+
+    return send_wol_bulk(
+        body.macs,
+        broadcast=body.broadcast,
+        port=body.port,
+        count=body.count,
+    )
+
+
+@router.get("/hosts/image-status", name="Last sync per host from the boot logs")
+def hosts_image_status(
+    who: AuthenticatedUser = Depends(RoleChecker("G")),
+):
+    """
+    ## Report the last applied image per host, read from the LINBO boot logs.
+
+    Hosts that never reported carry no entry.
+
+    ### Access
+    - global-administrators
+
+    \f
+    """
+
+
+    hosts = get_host_image_status()
+    return {"hosts": hosts, "total": len(hosts)}
+
+
+# ── Boot logs ──────────────────────────────────────────────────────
+
+
+@router.get("/boot-logs", name="List LINBO client boot logs")
+def list_boot_logs(
+    who: AuthenticatedUser = Depends(RoleChecker("G")),
+):
+    """
+    ## List the client boot logs, newest first.
+
+    ### Access
+    - global-administrators
+
+    \f
+    """
+
+
+    logs = LinboBootLogs().list_logs()
+    return {"logs": logs, "total": len(logs)}
+
+
+@router.get(
+    "/boot-logs/{filename}",
+    name="Read a LINBO client boot log",
+    response_class=PlainTextResponse,
+)
+def read_boot_log(
+    filename: str,
+    who: AuthenticatedUser = Depends(RoleChecker("G")),
+):
+    """
+    ## Read one boot log.
+
+    ### Access
+    - global-administrators
+
+    \f
+    :param filename: Name of the log file
+    """
+
+
+    try:
+        content = LinboBootLogs().read_log(filename)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    if content is None:
+        raise HTTPException(status_code=404, detail=f"Boot log {filename} not found")
+
+    return PlainTextResponse(content=content)
+
+
+@router.delete("/boot-logs/{filename}", name="Delete a LINBO client boot log")
+def delete_boot_log(
+    filename: str,
+    who: AuthenticatedUser = Depends(RoleChecker("G")),
+):
+    """
+    ## Delete one boot log.
+
+    ### Access
+    - global-administrators
+
+    \f
+    :param filename: Name of the log file
+    """
+
+
+    try:
+        deleted = LinboBootLogs().delete_log(filename)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    if not deleted:
+        raise HTTPException(status_code=404, detail=f"Boot log {filename} not found")
+
+    return {"filename": filename, "status": "deleted"}
 
 
 # ── Image Manifest ─────────────────────────────────────────────────


### PR DESCRIPTION
`linuxmusterTools.linbo` already implements probing hosts for online status (`host_status.scan_hosts_sync`), sending Wake-on-LAN packets (`wol.send_wol_bulk`), reading the last applied image per host out of the boot logs (`boot_logs.get_host_image_status`), and listing, reading and deleting those logs (`boot_logs.LinboBootLogs`).

None of it has a route. The only client that can use any of it today is a script running on the server itself, so a web frontend cannot tell whether a host is online, cannot wake one, and cannot show when it last synced.

## Endpoints

| Method | Path | Delegates to |
| --- | --- | --- |
| POST | `/linbo/hosts/scan` | `scan_hosts_sync` |
| POST | `/linbo/wol` | `send_wol_bulk` |
| GET | `/linbo/hosts/image-status` | `get_host_image_status` |
| GET | `/linbo/boot-logs` | `LinboBootLogs.list_logs` |
| GET | `/linbo/boot-logs/{filename}` | `LinboBootLogs.read_log` |
| DELETE | `/linbo/boot-logs/{filename}` | `LinboBootLogs.delete_log` |

They carry no logic of their own beyond argument validation and translating the errors the library already raises — an unsafe or oversized filename becomes 400, an absent log 404. The 500-MAC cap matches the existing `POST /linbo/hosts/query`, and an empty MAC list on `/linbo/hosts/scan` scans every client of the school, which is the common case for a dashboard.

All six are `RoleChecker("G")`, like every other LINBO route.

## Placement

The routes sit in the existing `linbo` router rather than in one of their own. `/linbo/hosts/query` is already there, and a second router on the same prefix would split one resource across two OpenAPI tags. The drivers router earns its own module because it owns a distinct `/linbo/drivers` prefix; these do not.

## Tests

`pytests/test_linbo_hosts.py`, 17 tests in the style of `test_linbo_drivers.py` — the managers are replaced via `monkeypatch`, so they need no live data and run anywhere the package imports.

Two differences from that file worth flagging, both deliberate:

- It asserts the six new routes are a **subset** of the router's routes rather than pinning the full set. `test_linbo_drivers.py` can pin its router exactly because it owns every route in it; this router has seventeen I did not write, and pinning them here would make this test the thing that breaks whenever someone adds an endpoint elsewhere.
- Instead it asserts the **invariant** that *every* route in the LINBO router has exactly one `RoleChecker` and that it is `globaladministrator`. That still catches an accidentally ungated endpoint, which is what the original assertion is for, without owning the route list.

## Verified

On an installed 7.4 server, against real data rather than only mocks:

```
scan:         5 hosts probed, 1 online
image-status: 5 hosts — pc100 last applied mint.qcow2 at 2026-04-28T12:37
boot-logs:    40 files
```

Test suite: 452 collected (up from 435), and the four files that need no LDAP fixtures — `test_linbo_hosts`, `test_linbo_drivers`, `test_checks`, `test_rate_limiter` — give 36 passed.


---

## Update after review

The endpoints are unchanged in shape; the guards around them were wrong in three ways.

**Packet parameters are now bounded in the schema** (`port` 1–65535, `count` 1–10, `broadcast` as `IPvAnyAddress`). `send_wol_bulk` multiplies `count` by the MAC count inside a blocking send loop, so an unbounded value held a worker thread for as long as the caller liked; a negative one sent nothing while still reporting every host as `successful`; and an unvalidated broadcast address let the server send UDP to any host it could reach. All three are rejected before a socket is opened.

**The host cap applies to the resolved list**, not only to the request. An empty MAC list resolves to every client of the school, which the request cap never saw — a 2000-client school reached `scan_hosts_sync` in full. Probes also run at a wider concurrency than the library default of 20, since the handler holds a thread until the last host answers or times out.

**An oversized log answers 413**, not 400. `read_log` raises `ValueError` for an unsafe filename *and* for a log over the size limit; a log that `GET /linbo/boot-logs` advertised one call earlier is not a bad request. Deleting now tolerates the file vanishing underneath it — `linuxmuster-linbo7` ships a logrotate rule for exactly this directory, so `FileNotFoundError` is scheduled, not hypothetical.

The handler is named `probe_hosts`: `scan_hosts` is a coroutine that `from linuxmusterTools.linbo import *` already binds in this module, and the three `*_endpoint` handlers further down exist for the same collision.

## Tests

17 → 33 in `test_linbo_hosts.py` (43 with parametrisation), plus 7 HTTP denial tests in `test_misc.py`'s `TestLinbo`.

The originals passed for the wrong reasons. Verified by mutation on a 7.4 server — each of these previously left all tests green:

| Mutation | Before | After |
| --- | --- | --- |
| delete `check_valid_school_or_404` from the scan handler | 17 passed | **2 failed** |
| `delete_log` deletes a hardcoded wrong filename | 17 passed | **7 failed** |
| cap the request only, not the resolved list | n/a | **1 failed** |

The traversal guard is now pinned against a real `LinboBootLogs` on a `tmp_path` rather than a mock, so `_SAFE_FILENAME` actually runs — including a positive case, without which the guard could degenerate to "reject everything" and still pass.

Full suite collects 509 tests. Against real data on the same server: 5 hosts probed (1 online), 5 hosts with sync history, 40 boot logs.

## One pre-existing bug found while reviewing, deliberately not touched here

`POST /linbo/hosts/query` with `{"macs": []}` returns **every device in the school**: the body passes the 500-check and reaches `Devices.filter()` with no filter, whose final branch is `return self.devices`. That is why this PR keeps `LinboHostScanBody` separate from `LinboBatchMacs` instead of giving the latter a default — unifying them would have widened that behaviour rather than fixed it. Happy to file it separately.
