### PR TITLE
Seed the test credentials so make test works on a clean checkout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 API_DIR = usr/lib/python3/dist-packages/linuxmusterApi
+CREDENTIALS = $(API_DIR)/pytests/credentials.py
 
 # The API ships its own interpreter; the system python3 has neither fastapi nor
 # linuxmusterTools. Override on a machine where it lives somewhere else.
@@ -9,7 +10,14 @@ all: build
 deb:
 	dpkg-buildpackage -rfakeroot -tc -sa -us -uc -I".gitignore" -I".git" -I".github" -I".idea" -I"docs"
 
-test:
+# conftest.py imports pytests/credentials.py unconditionally, and that file is
+# gitignored, so without this a fresh clone collects nothing at all: pytest aborts
+# on the conftest import before it reaches even the tests that mock everything.
+$(CREDENTIALS):
+	cp $(API_DIR)/pytests/credentials.sample.py $@
+	@echo "Created $@ from the sample. Fill in real users to run the integration tests."
+
+test: $(CREDENTIALS)
 	cd $(API_DIR) && $(PYTHON) -m pytest $(PYTEST_ARGS)
 
 .PHONY: all deb test


### PR DESCRIPTION
Follow-up to #28, which added the `make test` target but only worked where a credentials file already happened to exist.

`pytests/conftest.py` starts with

```python
from . import credentials
from .credentials import LOCAL_API_PATH
```

and `pytests/credentials.py` is gitignored — only `credentials.sample.py` is committed. A conftest that fails to import aborts pytest during collection, so on a fresh clone `make test` runs **not a single test**, including `test_linbo_drivers`, `test_checks` and `test_linbo_hosts`, which mock everything and need no server at all.

## What this changes

The target gains a file prerequisite that copies the committed sample when the file is missing:

```make
$(CREDENTIALS):
	cp $(API_DIR)/pytests/credentials.sample.py $@
	@echo "Created $@ from the sample. Fill in real users to run the integration tests."

test: $(CREDENTIALS)
	cd $(API_DIR) && $(PYTHON) -m pytest $(PYTEST_ARGS)
```

The sample carries placeholders, so the integration suites still need real LDAP users filled in — that is unchanged. What changes is that the suites which need nothing external now run out of the box.

## Verified

On an installed 7.4 server with `credentials.py` deleted: the copy step runs, then `make test PYTEST_ARGS="pytests/test_linbo_drivers.py pytests/test_checks.py -q"` gives **16 passed**. Before this change the same command aborted with `ImportError while loading conftest`.
