### PR TITLE
Harden the LINBO host state endpoints

### DIFF
--- a/usr/lib/python3/dist-packages/linuxmusterApi/pytests/test_linbo_hosts.py
+++ b/usr/lib/python3/dist-packages/linuxmusterApi/pytests/test_linbo_hosts.py
@@ -1,11 +1,25 @@
+from datetime import datetime, timedelta
 from unittest.mock import Mock
 
 import pytest
 from fastapi import HTTPException
 
+from linuxmusterTools.linbo import LinboBootLogs
+
 from routers_v1 import linbo
-from routers_v1.body_schemas import LinboHostScanRequest, LinboWolRequest
+from routers_v1.body_schemas import LinboHostScanBody, LinboWolBody
 from security import RoleChecker
+
+
+MAX_MACS = linbo.MAX_HOSTS_PER_SCAN
+TOO_MANY_MACS_DETAIL = f"Maximum {MAX_MACS} MACs per request"
+NO_MACS_DETAIL = "At least one MAC address is required"
+
+
+def _macs(count):
+    """Distinct MACs — a two-digit hex suffix starts repeating past 255."""
+
+    return [f"00:00:00:00:{index // 256:02x}:{index % 256:02x}" for index in range(count)]
 
 
 @pytest.fixture
@@ -15,14 +29,32 @@ def linbo_backends(monkeypatch):
     scan = Mock(return_value=[])
     wol = Mock(return_value={})
     image_status = Mock(return_value={})
+    check_school = Mock(side_effect=lambda school: school)
 
     monkeypatch.setattr(linbo, "Devices", lambda school: devices)
     monkeypatch.setattr(linbo, "LinboBootLogs", lambda: boot_logs)
     monkeypatch.setattr(linbo, "scan_hosts_sync", scan)
     monkeypatch.setattr(linbo, "send_wol_bulk", wol)
     monkeypatch.setattr(linbo, "get_host_image_status", image_status)
-    monkeypatch.setattr(linbo, "check_valid_school_or_404", lambda school: school)
-    return devices, boot_logs, scan, wol, image_status
+    monkeypatch.setattr(linbo, "check_valid_school_or_404", check_school)
+    return devices, boot_logs, scan, wol, image_status, check_school
+
+
+@pytest.fixture
+def real_boot_logs(monkeypatch, tmp_path):
+    """A real LinboBootLogs, so the library's filename guard actually runs."""
+
+    log_dir = tmp_path / "linbo"
+    log_dir.mkdir()
+    (log_dir / "pc100.log").write_text("sync finished")
+    secret = tmp_path / "shadow"
+    secret.write_text("root:!:19000:0:99999:7:::")
+
+    monkeypatch.setattr(linbo, "LinboBootLogs", lambda: LinboBootLogs(str(log_dir)))
+    return log_dir, secret
+
+
+# ── Routing and access ─────────────────────────────────────────────
 
 
 def test_new_routes_are_registered():
@@ -43,6 +75,10 @@ def test_new_routes_are_registered():
 
 
 def test_every_linbo_route_is_global_admin_only():
+    # An invariant over the whole router rather than a pinned route list: this
+    # router carries endpoints from several features, and a new one that forgets
+    # its Depends(RoleChecker("G")) has to fail here. This checks the declaration
+    # only — TestLinbo in test_misc.py covers the enforcement over HTTP.
     for route in linbo.router.routes:
         checkers = [
             dependency.call
@@ -53,118 +89,276 @@ def test_every_linbo_route_is_global_admin_only():
         assert checkers[0].roles == ["globaladministrator"], route.path
 
 
+# ── Scan ───────────────────────────────────────────────────────────
+
+
 def test_scan_without_macs_probes_every_client(linbo_backends):
-    devices, _, scan, _, _ = linbo_backends
+    devices, _, scan, _, _, check_school = linbo_backends
     clients = [{"mac": "00:11:22:33:44:55", "ip": "10.0.0.100", "hostname": "pc100"}]
     devices.get_clients.return_value = clients
-    scan.return_value = [{"mac": clients[0]["mac"], "online": True}]
+    scan.return_value = [
+        {
+            "mac": "00:11:22:33:44:55",
+            "ip": "10.0.0.100",
+            "hostname": "pc100",
+            "online": True,
+            "lastSeen": "2026-03-24T11:42:00+00:00",
+        },
+    ]
 
-    result = linbo.scan_hosts(LinboHostScanRequest(), "default-school", None)
+    result = linbo.probe_hosts(LinboHostScanBody(), "default-school", None)
 
-    scan.assert_called_once_with(clients)
+    check_school.assert_called_once_with("default-school")
+    scan.assert_called_once_with(clients, concurrency=linbo.SCAN_CONCURRENCY)
     devices.get_hosts_by_macs.assert_not_called()
     assert result["hosts"] == scan.return_value
-    assert "scannedAt" in result
 
 
 def test_scan_with_macs_probes_only_those_hosts(linbo_backends):
-    devices, _, scan, _, _ = linbo_backends
+    devices, _, scan, _, _, _ = linbo_backends
     macs = ["00:11:22:33:44:55"]
     hosts = [{"mac": macs[0], "ip": "10.0.0.100", "hostname": "pc100"}]
     devices.get_hosts_by_macs.return_value = hosts
 
-    linbo.scan_hosts(LinboHostScanRequest(macs=macs), "default-school", None)
+    linbo.probe_hosts(LinboHostScanBody(macs=macs), "default-school", None)
 
     devices.get_hosts_by_macs.assert_called_once_with(macs)
     devices.get_clients.assert_not_called()
-    scan.assert_called_once_with(hosts)
+    scan.assert_called_once_with(hosts, concurrency=linbo.SCAN_CONCURRENCY)
 
 
-def test_scan_rejects_more_than_500_macs(linbo_backends):
-    _, _, scan, _, _ = linbo_backends
-    body = LinboHostScanRequest(macs=[f"00:00:00:00:00:{i:02x}" for i in range(501)])
+def test_scan_validates_the_school_before_touching_the_filesystem(linbo_backends):
+    devices, _, scan, _, _, check_school = linbo_backends
+    check_school.side_effect = HTTPException(status_code=404, detail="Invalid school")
 
     with pytest.raises(HTTPException) as error:
-        linbo.scan_hosts(body, "default-school", None)
+        linbo.probe_hosts(LinboHostScanBody(), "../../tmp", None)
+
+    assert error.value.status_code == 404
+    devices.get_clients.assert_not_called()
+    devices.get_hosts_by_macs.assert_not_called()
+    scan.assert_not_called()
+
+
+def test_scan_rejects_more_than_the_mac_cap(linbo_backends):
+    _, _, scan, _, _, _ = linbo_backends
+    body = LinboHostScanBody(macs=_macs(MAX_MACS + 1))
+
+    with pytest.raises(HTTPException) as error:
+        linbo.probe_hosts(body, "default-school", None)
 
     assert error.value.status_code == 400
+    assert error.value.detail == TOO_MANY_MACS_DETAIL
+    scan.assert_not_called()
+
+
+def test_scan_accepts_exactly_the_mac_cap(linbo_backends):
+    devices, _, scan, _, _, _ = linbo_backends
+    macs = _macs(MAX_MACS)
+    hosts = [{"mac": mac, "ip": "10.0.0.100", "hostname": "pc100"} for mac in macs]
+    devices.get_hosts_by_macs.return_value = hosts
+
+    linbo.probe_hosts(LinboHostScanBody(macs=macs), "default-school", None)
+
+    scan.assert_called_once_with(hosts, concurrency=linbo.SCAN_CONCURRENCY)
+
+
+def test_scan_caps_the_resolved_host_list_too(linbo_backends):
+    # An empty MAC list resolves to every client of the school, which the request
+    # cap never sees.
+    devices, _, scan, _, _, _ = linbo_backends
+    devices.get_clients.return_value = [
+        {"mac": mac, "ip": "10.0.0.1", "hostname": "pc"} for mac in _macs(MAX_MACS + 1)
+    ]
+
+    with pytest.raises(HTTPException) as error:
+        linbo.probe_hosts(LinboHostScanBody(), "default-school", None)
+
+    assert error.value.status_code == 400
+    assert str(MAX_MACS) in error.value.detail
     scan.assert_not_called()
 
 
 def test_scan_without_any_host_is_404(linbo_backends):
-    devices, _, scan, _, _ = linbo_backends
+    devices, _, scan, _, _, _ = linbo_backends
     devices.get_clients.return_value = []
 
     with pytest.raises(HTTPException) as error:
-        linbo.scan_hosts(LinboHostScanRequest(), "default-school", None)
+        linbo.probe_hosts(LinboHostScanBody(), "default-school", None)
 
     assert error.value.status_code == 404
+    assert error.value.detail == "No hosts found"
     scan.assert_not_called()
 
 
-def test_wol_delegates_with_packet_parameters(linbo_backends):
-    _, _, _, wol, _ = linbo_backends
-    macs = ["00:11:22:33:44:55"]
-    wol.return_value = {"total": 1, "successful": 1, "failed": 0, "results": []}
+def test_scan_timestamp_is_utc_aware(linbo_backends):
+    devices, _, _, _, _, _ = linbo_backends
+    devices.get_clients.return_value = [{"mac": "00:11:22:33:44:55", "ip": "10.0.0.100"}]
 
-    body = LinboWolRequest(macs=macs, broadcast="10.0.0.255", port=7, count=5)
+    result = linbo.probe_hosts(LinboHostScanBody(), "default-school", None)
+    scanned_at = datetime.fromisoformat(result["scannedAt"])
+
+    # A naive datetime.now() parses back with tzinfo None; astimezone() would be
+    # aware but local.
+    assert scanned_at.tzinfo is not None
+    assert scanned_at.utcoffset() == timedelta(0)
+
+
+# ── Wake-on-LAN ────────────────────────────────────────────────────
+
+
+def test_wol_delegates_with_packet_parameters(linbo_backends):
+    _, _, _, wol, _, _ = linbo_backends
+    macs = ["00:11:22:33:44:55"]
+    wol.return_value = {
+        "total": 1,
+        "successful": 1,
+        "failed": 0,
+        "results": [{"macAddress": macs[0], "success": True, "error": None}],
+    }
+
+    body = LinboWolBody(macs=macs, broadcast="10.0.0.255", port=7, count=5)
     result = linbo.wake_hosts(body, None)
 
+    # broadcast is an IPvAnyAddress on the model and a str on the socket call.
     wol.assert_called_once_with(macs, broadcast="10.0.0.255", port=7, count=5)
     assert result == wol.return_value
 
 
+def test_wol_falls_back_to_the_schema_packet_defaults(linbo_backends):
+    _, _, _, wol, _, _ = linbo_backends
+    macs = ["00:11:22:33:44:55"]
+
+    linbo.wake_hosts(LinboWolBody(macs=macs), None)
+
+    wol.assert_called_once_with(macs, broadcast=None, port=9, count=3)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("count", 0),
+        ("count", -5),
+        ("count", 1000000),
+        ("port", 0),
+        ("port", 70000),
+        ("broadcast", "not-an-address"),
+    ],
+)
+def test_wol_packet_parameters_are_bounded_by_the_schema(field, value):
+    # Rejected before a socket is opened: an unbounded count is multiplied by the
+    # MAC count inside a blocking send loop, and a negative one sends nothing while
+    # send_wol_bulk still reports every host as successful.
+    with pytest.raises(ValueError):
+        LinboWolBody(macs=["00:11:22:33:44:55"], **{field: value})
+
+
 def test_wol_without_macs_is_rejected(linbo_backends):
-    _, _, _, wol, _ = linbo_backends
+    _, _, _, wol, _, _ = linbo_backends
 
     with pytest.raises(HTTPException) as error:
-        linbo.wake_hosts(LinboWolRequest(macs=[]), None)
+        linbo.wake_hosts(LinboWolBody(macs=[]), None)
 
     assert error.value.status_code == 400
+    assert error.value.detail == NO_MACS_DETAIL
     wol.assert_not_called()
 
 
-def test_wol_rejects_more_than_500_macs(linbo_backends):
-    _, _, _, wol, _ = linbo_backends
-    body = LinboWolRequest(macs=[f"00:00:00:00:00:{i:02x}" for i in range(501)])
+def test_wol_rejects_more_than_the_mac_cap(linbo_backends):
+    _, _, _, wol, _, _ = linbo_backends
+    body = LinboWolBody(macs=_macs(MAX_MACS + 1))
 
     with pytest.raises(HTTPException) as error:
         linbo.wake_hosts(body, None)
 
     assert error.value.status_code == 400
+    assert error.value.detail == TOO_MANY_MACS_DETAIL
     wol.assert_not_called()
 
 
-def test_image_status_reports_total(linbo_backends):
-    _, _, _, _, image_status = linbo_backends
-    image_status.return_value = {"pc100": {"lastSync": "2026-03-24T11:42:00.000Z"}}
+def test_wol_accepts_exactly_the_mac_cap(linbo_backends):
+    _, _, _, wol, _, _ = linbo_backends
+    macs = _macs(MAX_MACS)
+
+    linbo.wake_hosts(LinboWolBody(macs=macs), None)
+
+    wol.assert_called_once_with(macs, broadcast=None, port=9, count=3)
+
+
+# ── Image status ───────────────────────────────────────────────────
+
+
+def test_image_status_reports_one_entry_per_host(linbo_backends):
+    _, _, _, _, image_status, _ = linbo_backends
+    image_status.return_value = {
+        "pc100": {
+            "lastSync": "2026-03-24T11:42:00.000Z",
+            "action": "applied",
+            "image": "win11_pro.qcow2",
+            "imageVersion": "202601271107",
+        },
+        "pc101": {
+            "lastSync": "2026-03-24T11:44:00.000Z",
+            "action": "applied",
+            "image": "win11_pro.qcow2",
+            "imageVersion": "202601271107",
+        },
+        "pc102": {
+            "lastSync": "2026-03-25T08:03:00.000Z",
+            "action": "created",
+            "image": "ubuntu2404.qcow2",
+            "imageVersion": None,
+        },
+    }
 
     result = linbo.hosts_image_status(None)
 
-    assert result == {"hosts": image_status.return_value, "total": 1}
+    assert result["hosts"] == image_status.return_value
+    assert result["total"] == 3
 
 
-def test_boot_logs_are_listed_with_total(linbo_backends):
-    _, boot_logs, _, _, _ = linbo_backends
-    boot_logs.list_logs.return_value = [{"filename": "pc100.log", "size": 12}]
+# ── Boot logs ──────────────────────────────────────────────────────
+
+
+def test_boot_logs_are_listed_with_one_entry_per_file(linbo_backends):
+    _, boot_logs, _, _, _, _ = linbo_backends
+    boot_logs.list_logs.return_value = [
+        {"filename": "pc102.log", "size": 4096, "modifiedAt": "2026-03-25T08:03:11+00:00"},
+        {"filename": "pc101.log", "size": 2048, "modifiedAt": "2026-03-24T11:44:02+00:00"},
+        {"filename": "pc100.log", "size": 12, "modifiedAt": "2026-03-24T11:42:00+00:00"},
+    ]
 
     result = linbo.list_boot_logs(None)
 
-    assert result == {"logs": boot_logs.list_logs.return_value, "total": 1}
+    assert result["logs"] == boot_logs.list_logs.return_value
+    assert result["total"] == 3
 
 
 def test_boot_log_is_returned_as_plain_text(linbo_backends):
-    _, boot_logs, _, _, _ = linbo_backends
+    _, boot_logs, _, _, _, _ = linbo_backends
     boot_logs.read_log.return_value = "sync finished"
 
     response = linbo.read_boot_log("pc100.log", None)
 
     boot_logs.read_log.assert_called_once_with("pc100.log")
     assert response.body == b"sync finished"
+    assert response.media_type == "text/plain"
+
+
+def test_an_empty_boot_log_is_returned_as_an_empty_body(linbo_backends):
+    # The route must test `content is None`, not falsiness — a zero-byte log reads
+    # back as "" and is a 200, not a 404.
+    _, boot_logs, _, _, _, _ = linbo_backends
+    boot_logs.read_log.return_value = ""
+
+    response = linbo.read_boot_log("empty.log", None)
+
+    assert response.status_code == 200
+    assert response.body == b""
 
 
 def test_missing_boot_log_is_404(linbo_backends):
-    _, boot_logs, _, _, _ = linbo_backends
+    _, boot_logs, _, _, _, _ = linbo_backends
     boot_logs.read_log.return_value = None
 
     with pytest.raises(HTTPException) as error:
@@ -173,41 +367,121 @@ def test_missing_boot_log_is_404(linbo_backends):
     assert error.value.status_code == 404
 
 
-def test_unsafe_boot_log_name_is_400(linbo_backends):
-    _, boot_logs, _, _, _ = linbo_backends
+def test_read_log_value_error_maps_to_400(linbo_backends):
+    _, boot_logs, _, _, _, _ = linbo_backends
     boot_logs.read_log.side_effect = ValueError("Unsafe filename: ../../etc/shadow")
 
     with pytest.raises(HTTPException) as error:
         linbo.read_boot_log("../../etc/shadow", None)
 
     assert error.value.status_code == 400
+    assert "Unsafe filename" in error.value.detail
 
 
-def test_boot_log_deletion_reports_the_filename(linbo_backends):
-    _, boot_logs, _, _, _ = linbo_backends
+def test_an_oversized_boot_log_is_413_not_400(linbo_backends):
+    # read_log raises ValueError both for an unsafe name and for a log over the
+    # size limit. A log the list endpoint just advertised is not a bad request.
+    _, boot_logs, _, _, _, _ = linbo_backends
+    boot_logs.read_log.side_effect = ValueError("File too large: 7340032 bytes (max 5242880)")
+
+    with pytest.raises(HTTPException) as error:
+        linbo.read_boot_log("pc100.log", None)
+
+    assert error.value.status_code == 413
+
+
+def test_boot_log_deletion_delegates_the_filename(linbo_backends):
+    _, boot_logs, _, _, _, _ = linbo_backends
     boot_logs.delete_log.return_value = True
 
-    assert linbo.delete_boot_log("pc100.log", None) == {
-        "filename": "pc100.log",
-        "status": "deleted",
-    }
+    result = linbo.delete_boot_log("pc100.log", None)
+
+    boot_logs.delete_log.assert_called_once_with("pc100.log")
+    assert result == {"filename": "pc100.log", "status": "deleted"}
 
 
 def test_deleting_a_missing_boot_log_is_404(linbo_backends):
-    _, boot_logs, _, _, _ = linbo_backends
+    _, boot_logs, _, _, _, _ = linbo_backends
     boot_logs.delete_log.return_value = False
 
     with pytest.raises(HTTPException) as error:
         linbo.delete_boot_log("nope.log", None)
 
     assert error.value.status_code == 404
+    boot_logs.delete_log.assert_called_once_with("nope.log")
 
 
-def test_unsafe_name_on_delete_is_400(linbo_backends):
-    _, boot_logs, _, _, _ = linbo_backends
+def test_a_boot_log_deleted_concurrently_is_404(linbo_backends):
+    # logrotate rotates this directory, so a log can vanish between delete_log's
+    # is_file() and its unlink().
+    _, boot_logs, _, _, _, _ = linbo_backends
+    boot_logs.delete_log.side_effect = FileNotFoundError("gone")
+
+    with pytest.raises(HTTPException) as error:
+        linbo.delete_boot_log("pc100.log", None)
+
+    assert error.value.status_code == 404
+
+
+def test_an_undeletable_boot_log_is_500(linbo_backends):
+    _, boot_logs, _, _, _, _ = linbo_backends
+    boot_logs.delete_log.side_effect = PermissionError("read-only file system")
+
+    with pytest.raises(HTTPException) as error:
+        linbo.delete_boot_log("pc100.log", None)
+
+    assert error.value.status_code == 500
+
+
+def test_delete_log_value_error_maps_to_400(linbo_backends):
+    _, boot_logs, _, _, _, _ = linbo_backends
     boot_logs.delete_log.side_effect = ValueError("Unsafe filename: ../../etc/shadow")
 
     with pytest.raises(HTTPException) as error:
         linbo.delete_boot_log("../../etc/shadow", None)
 
     assert error.value.status_code == 400
+
+
+# ── The traversal guard itself, unmocked ───────────────────────────
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["../shadow", "../../etc/shadow", "sub/pc100.log", "/etc/shadow", "pc100.log;id"],
+)
+def test_reading_never_escapes_the_boot_log_directory(real_boot_logs, filename):
+    _, secret = real_boot_logs
+
+    with pytest.raises(HTTPException) as error:
+        linbo.read_boot_log(filename, None)
+
+    assert error.value.status_code == 400
+    assert secret.read_text().startswith("root:")
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["../shadow", "../../etc/shadow", "sub/pc100.log", "/etc/shadow"],
+)
+def test_deleting_never_escapes_the_boot_log_directory(real_boot_logs, filename):
+    _, secret = real_boot_logs
+
+    with pytest.raises(HTTPException) as error:
+        linbo.delete_boot_log(filename, None)
+
+    assert error.value.status_code == 400
+    assert secret.exists()
+
+
+def test_a_legitimate_boot_log_name_passes_the_traversal_guard(real_boot_logs):
+    # Without this the guard could degenerate to "reject everything" and the two
+    # tests above would still pass.
+    log_dir, _ = real_boot_logs
+
+    assert linbo.read_boot_log("pc100.log", None).body == b"sync finished"
+    assert linbo.delete_boot_log("pc100.log", None) == {
+        "filename": "pc100.log",
+        "status": "deleted",
+    }
+    assert not (log_dir / "pc100.log").exists()

--- a/usr/lib/python3/dist-packages/linuxmusterApi/pytests/test_misc.py
+++ b/usr/lib/python3/dist-packages/linuxmusterApi/pytests/test_misc.py
@@ -171,3 +171,58 @@ class TestLinbo:
         )
         assert r.status_code == 401
         assert 'Permission denied' in r.json()["detail"]
+
+    @pytest.mark.parametrize("user", USERS[1:])
+    def test_post_linbo_hosts_scan_denied(self, user):
+        r = client.post(
+            f"{BASE_URL}/linbo/hosts/scan",
+            headers={"X-API-KEY": user.jwt},
+            json={"macs": []},
+        )
+        assert r.status_code == 401
+        assert 'Permission denied' in r.json()["detail"]
+
+    @pytest.mark.parametrize("user", USERS[1:])
+    def test_post_linbo_wol_denied(self, user):
+        r = client.post(
+            f"{BASE_URL}/linbo/wol",
+            headers={"X-API-KEY": user.jwt},
+            json={"macs": ["00:11:22:33:44:55"]},
+        )
+        assert r.status_code == 401
+        assert 'Permission denied' in r.json()["detail"]
+
+    @pytest.mark.parametrize("user", USERS[1:])
+    def test_get_linbo_hosts_image_status_denied(self, user):
+        r = client.get(f"{BASE_URL}/linbo/hosts/image-status", headers={"X-API-KEY": user.jwt})
+        assert r.status_code == 401
+        assert 'Permission denied' in r.json()["detail"]
+
+    @pytest.mark.parametrize("user", USERS[1:])
+    def test_get_linbo_boot_logs_denied(self, user):
+        r = client.get(f"{BASE_URL}/linbo/boot-logs", headers={"X-API-KEY": user.jwt})
+        assert r.status_code == 401
+        assert 'Permission denied' in r.json()["detail"]
+
+    @pytest.mark.parametrize("user", USERS[1:])
+    def test_get_linbo_boot_log_denied(self, user):
+        r = client.get(
+            f"{BASE_URL}/linbo/boot-logs/pytest-nonexistent.log",
+            headers={"X-API-KEY": user.jwt},
+        )
+        assert r.status_code == 401
+        assert 'Permission denied' in r.json()["detail"]
+
+    @pytest.mark.parametrize("user", USERS[1:])
+    def test_delete_linbo_boot_log_denied(self, user):
+        r = client.delete(
+            f"{BASE_URL}/linbo/boot-logs/pytest-nonexistent.log",
+            headers={"X-API-KEY": user.jwt},
+        )
+        assert r.status_code == 401
+        assert 'Permission denied' in r.json()["detail"]
+
+    def test_get_linbo_boot_logs_ga(self):
+        r = client.get(f"{BASE_URL}/linbo/boot-logs", headers={"X-API-KEY": GLOBALADMIN.jwt})
+        assert r.status_code == 200
+        assert "logs" in r.json()

--- a/usr/lib/python3/dist-packages/linuxmusterApi/routers_v1/body_schemas.py
+++ b/usr/lib/python3/dist-packages/linuxmusterApi/routers_v1/body_schemas.py
@@ -2,7 +2,7 @@
 The purpose of this file is to gather all classes used as model for post data.
 """
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, IPvAnyAddress
 
 class UserList(BaseModel):
     """
@@ -258,24 +258,33 @@ class LinboBatchMacs(BaseModel):
 
     macs: list[str]
 
-class LinboHostScanRequest(BaseModel):
+class LinboHostScanBody(BaseModel):
     """
     MAC addresses to probe for online status. Empty means every client of the school.
+
+    Kept separate from LinboBatchMacs despite the same single field: an empty list
+    means "every client" here, while on /linbo/hosts/query it would reach
+    Devices.filter() with no filter at all and return every device of the school.
     """
 
 
     macs: list[str] = []
 
-class LinboWolRequest(BaseModel):
+class LinboWolBody(BaseModel):
     """
     MAC addresses to wake, with the magic packet parameters.
+
+    The packet parameters are bounded here rather than in the router: an
+    unbounded count is multiplied by the number of MAC addresses inside a
+    blocking send loop, and an unvalidated broadcast address makes the server
+    send UDP to any host it can reach.
     """
 
 
     macs: list[str]
-    broadcast: str | None = None
-    port: int = 9
-    count: int = 3
+    broadcast: IPvAnyAddress | None = None
+    port: int = Field(9, ge=1, le=65535)
+    count: int = Field(3, ge=1, le=10)
 
 class StartConfRawBody(BaseModel):
     """

--- a/usr/lib/python3/dist-packages/linuxmusterApi/routers_v1/linbo.py
+++ b/usr/lib/python3/dist-packages/linuxmusterApi/routers_v1/linbo.py
@@ -17,8 +17,8 @@ from security import AuthenticatedUser, RoleChecker
 from utils.checks import check_valid_school_or_404
 from .body_schemas import (
     LinboBatchMacs,
-    LinboHostScanRequest,
-    LinboWolRequest,
+    LinboHostScanBody,
+    LinboWolBody,
     StartConfRawBody,
 )
 
@@ -44,6 +44,11 @@ router = APIRouter(
 
 LINBO_DIR = Path("/srv/linbo")
 IMAGES_DIR = LINBO_DIR / "images"
+
+# A scan holds a worker thread until every host has answered or timed out, so the
+# host count is capped and the probes run wider than the library default of 20.
+MAX_HOSTS_PER_SCAN = 500
+SCAN_CONCURRENCY = 100
 
 
 def _parse_list_query(values: list[str], param_name: str, max_items: int) -> list[str]:
@@ -417,8 +422,8 @@ def dhcp_export_isc(
 
 
 @router.post("/hosts/scan", name="Probe hosts for online status")
-def scan_hosts(
-    body: LinboHostScanRequest,
+def probe_hosts(
+    body: LinboHostScanBody,
     school: str = "default-school",
     who: AuthenticatedUser = Depends(RoleChecker("G")),
 ):
@@ -438,8 +443,8 @@ def scan_hosts(
 
     check_valid_school_or_404(school)
 
-    if len(body.macs) > 500:
-        raise HTTPException(status_code=400, detail="Maximum 500 MACs per request")
+    if len(body.macs) > MAX_HOSTS_PER_SCAN:
+        raise HTTPException(status_code=400, detail=f"Maximum {MAX_HOSTS_PER_SCAN} MACs per request")
 
     devices_mgr = Devices(school=school)
     hosts = devices_mgr.get_hosts_by_macs(body.macs) if body.macs else devices_mgr.get_clients()
@@ -447,15 +452,24 @@ def scan_hosts(
     if not hosts:
         raise HTTPException(status_code=404, detail="No hosts found")
 
+    # The cap above only covers an explicit list; an empty one resolves to every
+    # client of the school, which is unbounded and would hold a worker thread for
+    # the whole scan.
+    if len(hosts) > MAX_HOSTS_PER_SCAN:
+        raise HTTPException(
+            status_code=400,
+            detail=f"School {school} has {len(hosts)} clients, more than the {MAX_HOSTS_PER_SCAN} a single scan allows",
+        )
+
     return {
-        "hosts": scan_hosts_sync(hosts),
+        "hosts": scan_hosts_sync(hosts, concurrency=SCAN_CONCURRENCY),
         "scannedAt": datetime.now(timezone.utc).isoformat(),
     }
 
 
 @router.post("/wol", name="Wake hosts with a magic packet")
 def wake_hosts(
-    body: LinboWolRequest,
+    body: LinboWolBody,
     who: AuthenticatedUser = Depends(RoleChecker("G")),
 ):
     """
@@ -472,12 +486,12 @@ def wake_hosts(
     if not body.macs:
         raise HTTPException(status_code=400, detail="At least one MAC address is required")
 
-    if len(body.macs) > 500:
-        raise HTTPException(status_code=400, detail="Maximum 500 MACs per request")
+    if len(body.macs) > MAX_HOSTS_PER_SCAN:
+        raise HTTPException(status_code=400, detail=f"Maximum {MAX_HOSTS_PER_SCAN} MACs per request")
 
     return send_wol_bulk(
         body.macs,
-        broadcast=body.broadcast,
+        broadcast=str(body.broadcast) if body.broadcast else None,
         port=body.port,
         count=body.count,
     )
@@ -547,7 +561,11 @@ def read_boot_log(
     try:
         content = LinboBootLogs().read_log(filename)
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        # read_log raises ValueError for an unsafe name and for a log over its size
+        # limit. Only the first is the caller's fault; a log the list endpoint just
+        # advertised is not a bad request.
+        status_code = 413 if "too large" in str(e).lower() else 400
+        raise HTTPException(status_code=status_code, detail=str(e))
 
     if content is None:
         raise HTTPException(status_code=404, detail=f"Boot log {filename} not found")
@@ -575,6 +593,13 @@ def delete_boot_log(
         deleted = LinboBootLogs().delete_log(filename)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    except FileNotFoundError:
+        # logrotate rotates and compresses this directory, so a log can disappear
+        # between delete_log's is_file() and its unlink(). Same answer as a log that
+        # was never there. FileNotFoundError is an OSError, so it is caught first.
+        raise HTTPException(status_code=404, detail=f"Boot log {filename} not found")
+    except OSError as e:
+        raise HTTPException(status_code=500, detail=f"Could not delete boot log {filename}: {e}")
 
     if not deleted:
         raise HTTPException(status_code=404, detail=f"Boot log {filename} not found")


### PR DESCRIPTION
Follow-up to #29. The endpoints are right in shape; the guards around them were not.

## Wake-on-LAN packet parameters are bounded in the schema

`send_wol_bulk` multiplies `count` by the number of MAC addresses inside a blocking send loop (`wol.py`, `for _ in range(count): sock.sendto(...)` per MAC), and the router forwarded the field verbatim. Three consequences, all measured against the real library:

- **Unbounded `count`** — `{"macs": [...500...], "count": 1000000}` is 500 million packets in one request. The handler is a sync `def`, so it holds an AnyIO worker thread for the duration and cannot be cancelled when the client disconnects.
- **Negative `count`** — `range(-5)` sends nothing, yet `send_wol_bulk` returns `{'total': 1, 'successful': 1, 'failed': 0}`. The API answered 200 "woken" for hosts that were never sent a packet.
- **Unvalidated `broadcast`** — passed straight to `sock.sendto`, so the destination was fully caller-chosen. A hostname there also triggers a blocking `getaddrinfo` per MAC.

```python
macs: list[str]
broadcast: IPvAnyAddress | None = None
port: int = Field(9, ge=1, le=65535)
count: int = Field(3, ge=1, le=10)
```

Bad input is now rejected with a 422 before a socket is opened.

## The host cap applies to the resolved list

The cap only guarded `body.macs`. An empty list takes the `get_clients()` branch, which is unbounded — a 2000-client school reached `scan_hosts_sync` in full. Since offline hosts always burn the full timeout, wall time is `ceil(N / concurrency) x 2s`, held in one of 40 threadpool tokens while every other endpoint in this API is also a sync `def`.

The cap now covers the resolved list, and probes run at 100 rather than the library default of 20. Both limits are named constants.

## Error mapping

`read_log` raises `ValueError` for an unsafe filename **and** for a log over `MAX_FILE_SIZE`. A 7 MB log — exactly the case the limit exists for — answered `400 Bad Request` for a file `GET /linbo/boot-logs` had listed one call earlier. That case is now **413**; the filename case stays 400.

`delete_log` now tolerates the file vanishing between its `is_file()` and its `unlink()`. This is scheduled rather than hypothetical: `linuxmuster-linbo7` ships a logrotate rule that rotates and compresses `/var/log/linuxmuster/linbo/*.log`. `FileNotFoundError` maps to the same 404 the route already returns for a missing log, and is caught before `OSError`.

## Naming

`scan_hosts` is a coroutine that `from linuxmusterTools.linbo import *` already binds in this module, and the endpoint rebound the name — leaving the library function unreachable from here. Renamed to `probe_hosts`, matching the reason `upload_status_endpoint`, `finalize_upload_endpoint` and `cancel_upload_endpoint` carry their suffixes.

The two request models are renamed to `LinboHostScanBody` / `LinboWolBody`, matching `StartConfRawBody`. They stay separate from `LinboBatchMacs` deliberately — see the note at the end.

## Tests

17 to 33 (43 with parametrisation), plus 7 HTTP denial tests in `test_misc.py`'s `TestLinbo`.

The previous tests passed for the wrong reasons. Mutation-tested on an installed 7.4 server:

| Mutation | Before | After |
| --- | --- | --- |
| remove `check_valid_school_or_404` from the scan handler | 17 passed | **2 failed** |
| `delete_log` acts on a hardcoded filename | 17 passed | **7 failed** |
| cap the request only, not the resolved list | n/a | **1 failed** |

The traversal guard is now exercised against a real `LinboBootLogs` on a `tmp_path` rather than a mock, so `_SAFE_FILENAME` actually runs — including a positive case, without which the guard could degenerate to "reject everything" and still pass. `test_misc.py` covers the HTTP denial path, which the route-declaration assertion cannot: it inspects `route.dependant`, so inverting `RoleChecker.__call__` would leave it green.

52 passed standalone; the full suite collects 509.

## One pre-existing bug, deliberately not touched here

`POST /linbo/hosts/query` with `{"macs": []}` returns **every device in the school**: the body passes the 500-check and reaches `Devices.filter()` with no filter set, whose final branch is `return self.devices`. That is why `LinboHostScanBody` stays a separate model rather than putting a `= []` default on `LinboBatchMacs` — that would widen the existing behaviour instead of fixing it. Happy to send a separate PR if you would like it closed.
