### PR TITLE
Added cn to user list

### DIFF
--- a/usr/lib/python3/dist-packages/linuxmusterApi/routers_v1/users.py
+++ b/usr/lib/python3/dist-packages/linuxmusterApi/routers_v1/users.py
@@ -35,7 +35,7 @@ def get_all_users(who: AuthenticatedUser = Depends(RoleChecker("G"))):
     """
 
 
-    return lr.get('/users', attributes=['sn', 'givenName', 'sophomorixRole', 'sophomorixAdminClass'])
+    return lr.get('/users', attributes=['cn', 'sn', 'givenName', 'sophomorixRole', 'sophomorixAdminClass'])
 
 @router.get("/{user}", name="User details")
 def get_user(user: str, check_first_pw: bool = False, who: AuthenticatedUser = Depends(UserChecker("GST"))):


### PR DESCRIPTION
Currently the user list does not contain the "cn" attribute required to fetch the full user details using the /v1/users/{user} endpoint where {user} is the cn of the user.

This PR adds the "cn" attribute to the list response to have a unique identifier in the list response and allow to fetch the full user details.